### PR TITLE
Loggear el stacktrace cuando hay un error en launchEvents

### DIFF
--- a/src/main/java/org/keedio/flume/source/watchdir/listener/simpletxtsource/FileEventHelper.java
+++ b/src/main/java/org/keedio/flume/source/watchdir/listener/simpletxtsource/FileEventHelper.java
@@ -72,6 +72,7 @@ public class FileEventHelper {
 		} catch (Exception e) {
 			LOGGER.error("Error procesando el fichero: " + path);
 			LOGGER.error(e.getMessage());
+			LOGGER.error(e.getStackTrace());
 
 			throw e;
 		}


### PR DESCRIPTION
e.getMessage() puede ser un string vacío y por lo tanto no mostrarse.
Dado que es un componente especializado en leer ficheros el único fallo
que no puede tener es no leer adecuadamente algún fichero. Por eso dado
el caso debería tener toda la información posible.
